### PR TITLE
Fix complete set styles

### DIFF
--- a/frontend/src/components/complete-set-table/complete-set-table-collapsed.tsx
+++ b/frontend/src/components/complete-set-table/complete-set-table-collapsed.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { ComplectationDetailsType } from '@autoline/shared/common/types/types';
 import { CompleteSetPropsType } from '@common/types/types';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
-import { Collapse } from '@mui/material';
 
 import { CompleteSetTable } from './complete-set-table';
 import styles from './styles.module.scss';
@@ -36,9 +35,7 @@ const CompleteSetTableCollapsed: React.FC<CompleteSetPropsType> = (props) => {
     <>
       {rowsHidden > 0 ? (
         <>
-          <Collapse in={open} timeout="auto" collapsedSize="215px">
-            <CompleteSetTable data={carsDisplayed} className={className} />
-          </Collapse>
+          <CompleteSetTable data={carsDisplayed} className={className} />
           <button className={styles.collapseButton} onClick={handleClick}>
             {open ? (
               <ExpandLess />

--- a/frontend/src/components/complete-set-table/styles.module.scss
+++ b/frontend/src/components/complete-set-table/styles.module.scss
@@ -15,7 +15,6 @@
       height: 35px;
       padding: 0.3rem 0.9rem;
       font-family: var(--primary-font);
-      line-height: 14px;
       border-bottom: 0;
     }
   }


### PR DESCRIPTION
MUI Collapse was removed from Complete set table as it required height set in pixels.