### PR TITLE
fix/Bug_70 Empty pills in applied filters bar

### DIFF
--- a/frontend/src/components/advanced-auto-filter/brand-details/brand-details.tsx
+++ b/frontend/src/components/advanced-auto-filter/brand-details/brand-details.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useEffect, useMemo } from 'react';
 
 import { AutocompleteValueType } from '@common/types/cars/autocomplete.type';
 import { BrandDetailsType } from '@common/types/cars/brand-details.type';
@@ -8,9 +8,10 @@ import { MultiselectInput } from '@components/common/multiselect-input/multisele
 import { SelectField } from '@components/common/select-field/select-field';
 import { Spinner } from '@components/common/spinner/spinner';
 import { getValueById } from '@helpers/get-value-by-id';
-import { useAppSelector } from '@hooks/store/store.hooks';
+import { useAppDispatch, useAppSelector } from '@hooks/store/store.hooks';
 import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
 import { Box, IconButton } from '@mui/material';
+import { setModels } from '@store/car-models/slice';
 import {
   useGetBrandsQuery,
   useGetModelsOfBrandQuery,
@@ -34,6 +35,8 @@ const BrandDetails: FC<Props> = ({
   onBrandDetailsChange,
   onBrandDetailsRemove,
 }) => {
+  const dispatch = useAppDispatch();
+
   const { length: brandDetailsLength } = useAppSelector(
     (state) => state.carFilter.brandDetails,
   );
@@ -42,6 +45,10 @@ const BrandDetails: FC<Props> = ({
   const { data: models } = useGetModelsOfBrandQuery(brandId, {
     skip: !brandId,
   });
+
+  useEffect(() => {
+    models && dispatch(setModels(models));
+  }, [models]);
 
   const notAppliedBrands = useAppSelector(selectNotAppliedBrands);
 
@@ -78,7 +85,7 @@ const BrandDetails: FC<Props> = ({
             id: item.id,
           } as AutocompleteValueType),
       ),
-    [brands],
+    [brands, notAppliedBrands],
   );
 
   const modelsOptions = useMemo(

--- a/frontend/src/components/applied-filters-bar/applied-filters-bar.tsx
+++ b/frontend/src/components/applied-filters-bar/applied-filters-bar.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 
-import { ModelType } from '@autoline/shared/common/types/types';
 import { CheckListsNames } from '@common/enums/car/car-filters-names.enum';
 import { AppliedFilterType } from '@common/types/cars/applied-filter.type';
 import { getRangeSymbol } from '@helpers/car-filters/get-range-symbol';
@@ -14,9 +13,7 @@ import {
   setBrandDetailsValue,
   setCheckListValue,
 } from '@store/car-filter/slice';
-import { useLazyGetModelsOfBrandQuery } from '@store/queries/cars';
 import {
-  selectAppliedBrands,
   selectNormalizedBrands,
   selectNormalizedOptionsInAutocompleteType,
 } from '@store/selectors/car-filter-selectors';
@@ -36,35 +33,13 @@ const AppliedFiltersBar = (): ReactElement => {
   const [appliedBrandDetails, setAppliedBrandDetails] =
     useState<AppliedFilterType[]>();
 
-  const [normalizedModels, setNormalizedModels] = useState<{
-    [p: string]: ModelType;
-  }>({});
+  const normalizedModels = useAppSelector((state) => state.carModels);
 
   const normalizedOptions = useAppSelector(
     selectNormalizedOptionsInAutocompleteType,
   );
 
   const normalizedBrands = useAppSelector(selectNormalizedBrands);
-
-  const allAppliedBrands = useAppSelector(selectAppliedBrands);
-
-  const [getModelsOfBrand, models] = useLazyGetModelsOfBrandQuery();
-
-  useEffect(() => {
-    allAppliedBrands.forEach((brandId) => {
-      getModelsOfBrand(brandId, true);
-    });
-  }, [brandDetails]);
-
-  useEffect(() => {
-    if (!models.data) return;
-
-    const newModels = models.data.reduce(
-      (obj, item) => ({ ...obj, [item.id]: item }),
-      {},
-    );
-    setNormalizedModels({ ...normalizedModels, ...newModels });
-  }, [models]);
 
   const handleRangeDelete = (rangeName: string): void => {
     dispatch(removeRangeValue(rangeName));

--- a/frontend/src/components/simple-auto-filter/simple-auto-filter.tsx
+++ b/frontend/src/components/simple-auto-filter/simple-auto-filter.tsx
@@ -25,6 +25,7 @@ import {
   setCheckListValue,
   setRangeValue,
 } from '@store/car-filter/slice';
+import { setModels } from '@store/car-models/slice';
 import { setCars } from '@store/found-car/slice';
 import { API } from '@store/queries/api-routes';
 import {
@@ -50,6 +51,10 @@ const SimpleAutoFilter: FC = () => {
   const { data: models } = useGetModelsOfBrandQuery(brandId, {
     skip: !brandId,
   });
+
+  useEffect(() => {
+    models && dispatch(setModels(models));
+  }, [models]);
 
   const [queryParams, setQueryParams] = useState<string[][]>();
 

--- a/frontend/src/store/car-models/slice.ts
+++ b/frontend/src/store/car-models/slice.ts
@@ -1,0 +1,26 @@
+import { ModelType } from '@autoline/shared/common/types/types';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type NormalizedModelsType = { [p: string]: { id: string; name: string } };
+
+const initialState: NormalizedModelsType = {};
+
+const { reducer, actions } = createSlice({
+  name: 'car-models',
+  initialState,
+  reducers: {
+    setModels: (state, action: PayloadAction<ModelType[]>) => {
+      const newModels = action.payload.reduce(
+        (obj, item) => ({ ...obj, [item.id]: item }),
+        {},
+      );
+
+      return { ...state, ...newModels };
+    },
+  },
+  extraReducers: {},
+});
+
+export const { setModels } = actions;
+
+export { reducer };

--- a/frontend/src/store/queries/cars/index.ts
+++ b/frontend/src/store/queries/cars/index.ts
@@ -42,7 +42,6 @@ export const carsApi = api.injectEndpoints({
 export const {
   useGetBrandsQuery,
   useGetModelsOfBrandQuery,
-  useLazyGetModelsOfBrandQuery,
   useGetUsedOptionsQuery,
   useLazyGetFilteredCarsQuery,
   useGetModelDetailsQuery,

--- a/frontend/src/store/root-reducer.ts
+++ b/frontend/src/store/root-reducer.ts
@@ -1,3 +1,4 @@
 export { reducer as auth, setCredentials, logOut } from './auth/slice';
 export { reducer as carFilter } from './car-filter/slice';
+export { reducer as carModels } from './car-models/slice';
 export { reducer as foundCars } from './found-car/slice';

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -4,11 +4,12 @@ import { api } from '@store/queries';
 import { combineReducers } from 'redux';
 
 import { checkTokenMiddleware } from './queries/preferences/middlewares';
-import { auth, carFilter, foundCars } from './root-reducer';
+import { auth, carFilter, carModels, foundCars } from './root-reducer';
 
 const rootReducer = combineReducers({
   auth,
   carFilter,
+  carModels,
   foundCars,
   [api.reducerPath]: api.reducer,
 });


### PR DESCRIPTION
See - https://app.asana.com/0/1202525679663009/1202951564209233/f

### **Before:** 
![pills-before](https://user-images.githubusercontent.com/49813216/189490797-2c147fea-9e54-4e2e-a9c8-5239153e1442.gif)

### **After:**
![pills-after](https://user-images.githubusercontent.com/49813216/189491032-6ae42154-2f61-4240-89c4-7035ab20446b.gif)


**Also solved an issue** where we may see duplicating brands when we initially added multiple empty brand-model fields and then chose brands.
(Fix on `brand-details.tsx` - line 88) 