### PR TITLE
fix/Bug_78 Reset filters in simple form rendering

### DIFF
--- a/frontend/src/components/simple-auto-filter/simple-auto-filter.tsx
+++ b/frontend/src/components/simple-auto-filter/simple-auto-filter.tsx
@@ -20,6 +20,7 @@ import { getValueById } from '@helpers/get-value-by-id';
 import { useAppDispatch, useAppSelector } from '@hooks/store/store.hooks';
 import { Button, Zoom } from '@mui/material';
 import {
+  resetAllFilters,
   setBrandDetailsValue,
   setCheckListValue,
   setRangeValue,
@@ -52,6 +53,10 @@ const SimpleAutoFilter: FC = () => {
   const { data: models } = useGetModelsOfBrandQuery(brandId, {
     skip: !brandId,
   });
+
+  useEffect(() => {
+    dispatch(resetAllFilters());
+  }, []);
 
   useEffect(() => {
     models && dispatch(setModels(models));


### PR DESCRIPTION
I decided to reset filters if the simple form renders. Because in our previous decision (reset on leave `/search` page) user could click on some car in search results, go to the detail view, then go back to the `/search` page and filters would be empty.

### Result:
![reset-filters](https://user-images.githubusercontent.com/49813216/189643512-b4944309-1a30-4eda-a083-b08f68269e3f.gif)

