### PR TITLE
Simplify Equal height logic

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "clsx": "1.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-equal-height": "^1.2.2",
     "react-hook-form": "^7.34.2",
     "react-imask": "^6.4.2",
     "react-redux": "^8.0.2",

--- a/frontend/src/assets/css/styles.scss
+++ b/frontend/src/assets/css/styles.scss
@@ -39,3 +39,11 @@ body,
     box-shadow: inset 0 0 6px #032081;
   }
 }
+
+.table {
+  .equal-height-JlocK:last-child {
+    .tableCell {
+      border-bottom: none;
+    }
+  }
+}

--- a/frontend/src/components/comparison-options-table/options-subtable.tsx
+++ b/frontend/src/components/comparison-options-table/options-subtable.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useLayoutEffect } from 'react';
+import React from 'react';
+import { EqualHeight, EqualHeightElement } from 'react-equal-height';
 import { ScrollSyncPane } from 'react-scroll-sync';
 
 import { CollapseElement } from '@components/collapse-component/collapse-element/collapse-element';
 import { Spinner } from '@components/common/spinner/spinner';
-import { getElementHeightWithMargins } from '@helpers/utils/get-element-height-with-margins';
 import { uuid4 } from '@sentry/utils';
 import {
   useGetComparisonGeneralInfoQuery,
@@ -37,66 +37,41 @@ const OptionsSubtable: React.FC<{ title: string }> = ({ title }) => {
     return <p style={{ color, margin: '0', fontSize: 20 }}>{symbol}</p>;
   };
 
-  const [optionsTable, setOptionsTableRef] = useState<HTMLDivElement | null>(
-    null,
-  );
-
-  useLayoutEffect(() => {
-    if (!optionsTable) return;
-    const optionTitle = optionsTable.querySelectorAll(
-      '[data-title]',
-    ) as NodeListOf<HTMLDivElement>;
-
-    optionTitle.forEach((option) => {
-      const title = option.getAttribute('data-title');
-      const tableElement = optionsTable.querySelectorAll(
-        `[data-value="${title}"]`,
-      ) as NodeListOf<HTMLDivElement>;
-
-      tableElement.forEach(
-        (element) =>
-          (element.style.height = `${
-            getElementHeightWithMargins(option) + 1
-          }px`),
-      );
-    });
-  }, [optionsTable, optionNames]);
-
   return (
     <CollapseElement label={title}>
       {isLoading ? (
         <Spinner />
       ) : (
-        <div className={styles.table} ref={setOptionsTableRef}>
-          <div className={clsx(styles.tableTitles, styles.tableColumn)}>
-            {optionNames?.map((option) => (
-              <div
-                className={styles.tableCell}
-                key={uuid4()}
-                data-title={option}
-              >
-                {option}
-              </div>
-            ))}
-          </div>
-          <ScrollSyncPane>
-            <div className={clsx('styledScrollbar', styles.generalInfo)}>
-              {cars?.map((car) => (
-                <div className={styles.tableColumn} key={uuid4()}>
-                  {optionNames?.map((optionName) => (
-                    <div
-                      className={styles.tableCell}
-                      key={uuid4()}
-                      data-value={optionName}
-                    >
-                      {getOptionSymbol(car.options[title].includes(optionName))}
-                    </div>
-                  ))}
-                </div>
+        <EqualHeight>
+          <div className={clsx(styles.table, 'table')}>
+            <div className={clsx(styles.tableTitles, styles.tableColumn)}>
+              {optionNames?.map((option) => (
+                <EqualHeightElement name={option} key={uuid4()}>
+                  <div className={clsx(styles.tableCell, 'tableCell')}>
+                    {option}
+                  </div>
+                </EqualHeightElement>
               ))}
             </div>
-          </ScrollSyncPane>
-        </div>
+            <ScrollSyncPane>
+              <div className={clsx('styledScrollbar', styles.generalInfo)}>
+                {cars?.map((car) => (
+                  <div className={styles.tableColumn} key={uuid4()}>
+                    {optionNames?.map((optionName) => (
+                      <EqualHeightElement name={optionName} key={uuid4()}>
+                        <div className={clsx(styles.tableCell, 'tableCell')}>
+                          {getOptionSymbol(
+                            car.options[title].includes(optionName),
+                          )}
+                        </div>
+                      </EqualHeightElement>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </ScrollSyncPane>
+          </div>
+        </EqualHeight>
       )}
     </CollapseElement>
   );

--- a/frontend/src/components/comparison-options-table/styles.module.scss
+++ b/frontend/src/components/comparison-options-table/styles.module.scss
@@ -15,15 +15,13 @@
 }
 
 .tableCell {
+  height: 100%;
   min-height: 45px;
   margin: 0 1rem;
   padding: 1rem 0;
   line-height: 1.6;
   text-transform: capitalize;
-
-  &:not(:last-child) {
-    border-bottom: 1px solid var(--gray300);
-  }
+  border-bottom: 1px solid var(--gray300);
 }
 
 .tableColumn {

--- a/frontend/src/components/general-comparison-table/general-comparison-table.tsx
+++ b/frontend/src/components/general-comparison-table/general-comparison-table.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
+import { EqualHeight, EqualHeightElement } from 'react-equal-height';
 import { ScrollSyncPane } from 'react-scroll-sync';
 
 import { CollapseElement } from '@components/collapse-component/collapse-element/collapse-element';
 import { Spinner } from '@components/common/spinner/spinner';
-import { getElementHeightWithMargins } from '@helpers/utils/get-element-height-with-margins';
 import { uuid4 } from '@sentry/utils';
 import { useGetComparisonGeneralInfoQuery } from '@store/queries/comparisons';
 import { clsx } from 'clsx';
@@ -27,10 +27,6 @@ const GeneralComparisonTable: React.FC = () => {
     return options;
   }, [generalInfo]);
 
-  const [generalTable, setGeneralTableRef] = useState<HTMLDivElement | null>(
-    null,
-  );
-
   const broadcast = new BroadcastChannel('compare');
   useEffect(() => {
     broadcast.onmessage = (): void => {
@@ -38,132 +34,103 @@ const GeneralComparisonTable: React.FC = () => {
     };
   }, [broadcast, refetch]);
 
-  useLayoutEffect(() => {
-    if (!generalTable) return;
-
-    //Get all options table cells
-    const optionsValuesElements = generalTable.querySelectorAll(
-      '[data-optionvalue]',
-    ) as NodeListOf<HTMLDivElement>;
-    const optionsValues = [...optionsValuesElements];
-
-    //Create list of heights for all options
-    const optionsHighestHeights = new Map();
-
-    //Go through all options cells to find the larger height of cell
-    optionsValues.forEach((value: HTMLDivElement) => {
-      const borderHeight = 1;
-      //Get height and option title of current table cell
-      const height = getElementHeightWithMargins(value) + borderHeight;
-      const title = value.getAttribute('data-optionvalue');
-
-      //If current table cell has larger height then similar cell of other car, accept it as highest height
-      if (
-        height > optionsHighestHeights.get(title) ||
-        !optionsHighestHeights.has(title)
-      ) {
-        optionsHighestHeights.set(title, height);
-      }
-    });
-
-    //Go through all options cells to set heights of cells
-    optionsValues.forEach((value: HTMLDivElement) => {
-      const title = value.getAttribute('data-optionvalue');
-      //Get title cell of the option, e.g. `Security`
-      const tableTitleElement = generalTable.querySelector(
-        `[data-optiontitle=${title}]`,
-      ) as HTMLDivElement;
-
-      //Set the same height for similar options of cars and their titles
-      //e.g. `Security` cells for all cars have height 100px
-      value.style.height = `${optionsHighestHeights.get(title)}px`;
-      tableTitleElement.style.height = `${optionsHighestHeights.get(title)}px`;
-    });
-  }, [generalTable, generalInfo]);
-
   if (isLoading) return <Spinner />;
 
   return (
     <CollapseElement label="General information" isOpen={true}>
-      <div className={styles.table} ref={setGeneralTableRef}>
-        <div className={clsx(styles.tableTitles, styles.tableColumn)}>
-          <div className={styles.tableCell} data-optiontitle="bodytype">
-            Type
-          </div>
-          <div className={styles.tableCell} data-optiontitle="motor">
-            Motor
-          </div>
-          <div className={styles.tableCell} data-optiontitle="enginepower">
-            Engine Power
-          </div>
-          <div className={styles.tableCell} data-optiontitle="engine">
-            Engine
-          </div>
-          <div className={styles.tableCell} data-optiontitle="wheeldrive">
-            Wheel Drive
-          </div>
-          {[...options].map((option) => (
-            <div
-              className={styles.tableCell}
-              data-optiontitle={option}
-              key={uuid4()}
-            >
-              {option}
-            </div>
-          ))}
-          <div className={styles.tableCell}>Color</div>
-        </div>
-        <ScrollSyncPane>
-          <div className={clsx('styledScrollbar', styles.generalInfo)}>
-            {generalInfo?.map((info) => {
-              return (
+      <EqualHeight>
+        <div className={styles.table}>
+          <div className={clsx(styles.tableTitles, styles.tableColumn)}>
+            <EqualHeightElement name="bodytype">
+              <div className={styles.tableCell}>Type</div>
+            </EqualHeightElement>
+            <EqualHeightElement name="motor">
+              <div className={styles.tableCell}>Motor</div>
+            </EqualHeightElement>
+            <EqualHeightElement name="enginepower">
+              <div className={styles.tableCell}>Engine Power</div>
+            </EqualHeightElement>
+            <EqualHeightElement name="engine">
+              <div className={styles.tableCell}>Engine</div>
+            </EqualHeightElement>
+            <EqualHeightElement name="wheeldrive">
+              <div className={styles.tableCell}>Wheel Drive</div>
+            </EqualHeightElement>
+            {[...options].map((option) => (
+              <EqualHeightElement name={option}>
                 <div
-                  className={clsx(styles.tableData, styles.tableColumn)}
-                  key={info.id}
+                  className={styles.tableCell}
+                  data-optiontitle={option}
+                  key={uuid4()}
                 >
-                  <div className={styles.tableCell} data-optionvalue="bodytype">
-                    {info.bodyType}
-                  </div>
-                  <div className={styles.tableCell} data-optionvalue="motor">
-                    {info.engineDisplacement} l.
-                  </div>
-                  <div
-                    className={styles.tableCell}
-                    data-optionvalue="enginepower"
-                  >
-                    {info.enginePower} h.p.
-                  </div>
-                  <div className={styles.tableCell} data-optionvalue="engine">
-                    {info.engine}
-                  </div>
-                  <div
-                    className={styles.tableCell}
-                    data-optionvalue="wheeldrive"
-                  >
-                    {info.drivetrainName}
-                  </div>
-                  {Object.keys(info.options).map((type: string) => (
-                    <div
-                      className={styles.tableCell}
-                      data-optionvalue={type}
-                      key={uuid4()}
-                    >
-                      {info.options[type].join(', ')}
-                    </div>
-                  ))}
-                  <div className={clsx(styles.tableCell, styles.colorCell)}>
-                    <div
-                      className={styles.colorBox}
-                      style={{ backgroundColor: info.colorName }}
-                    />
-                    <span>{info.colorName}</span>
-                  </div>
+                  {option}
                 </div>
-              );
-            })}
+              </EqualHeightElement>
+            ))}
+            <EqualHeightElement name="color">
+              <div className={clsx(styles.tableCell, styles.lastCell)}>
+                Color
+              </div>
+            </EqualHeightElement>
           </div>
-        </ScrollSyncPane>
-      </div>
+          <ScrollSyncPane>
+            <div className={clsx('styledScrollbar', styles.generalInfo)}>
+              {generalInfo?.map((info) => {
+                return (
+                  <div
+                    className={clsx(styles.tableData, styles.tableColumn)}
+                    key={info.id}
+                  >
+                    <EqualHeightElement name="bodytype">
+                      <div className={styles.tableCell}>{info.bodyType}</div>
+                    </EqualHeightElement>
+                    <EqualHeightElement name="motor">
+                      <div className={styles.tableCell}>
+                        {info.engineDisplacement} l.
+                      </div>
+                    </EqualHeightElement>
+                    <EqualHeightElement name="enginepower">
+                      <div className={styles.tableCell}>
+                        {info.enginePower} h.p.
+                      </div>
+                    </EqualHeightElement>
+                    <EqualHeightElement name="engine">
+                      <div className={styles.tableCell}>{info.engine}</div>
+                    </EqualHeightElement>
+                    <EqualHeightElement name="wheeldrive">
+                      <div className={styles.tableCell}>
+                        {info.drivetrainName}
+                      </div>
+                    </EqualHeightElement>
+                    {Object.keys(info.options).map((type: string) => (
+                      <EqualHeightElement name={type} key={uuid4()}>
+                        <div className={styles.tableCell}>
+                          {info.options[type].join(', ')}
+                        </div>
+                      </EqualHeightElement>
+                    ))}
+                    <EqualHeightElement name="color">
+                      <div
+                        className={clsx(
+                          styles.tableCell,
+                          styles.colorCell,
+                          styles.lastCell,
+                        )}
+                      >
+                        <div
+                          className={styles.colorBox}
+                          style={{ backgroundColor: info.colorName }}
+                        />
+                        <span>{info.colorName}</span>
+                      </div>
+                    </EqualHeightElement>
+                  </div>
+                );
+              })}
+            </div>
+          </ScrollSyncPane>
+        </div>
+      </EqualHeight>
     </CollapseElement>
   );
 };

--- a/frontend/src/components/general-comparison-table/general-comparison-table.tsx
+++ b/frontend/src/components/general-comparison-table/general-comparison-table.tsx
@@ -85,43 +85,51 @@ const GeneralComparisonTable: React.FC<{ isOnlyDiff: boolean }> = ({
   return (
     <CollapseElement label="General information" isOpen={true}>
       <EqualHeight>
-        <div className={styles.table}>
+        <div className={clsx(styles.table, 'table')}>
           <div className={clsx(styles.tableTitles, styles.tableColumn)}>
             {(!isOnlyDiff || !isIdentical.bodyType) && (
               <EqualHeightElement name="bodytype">
-                <div className={styles.tableCell}>Type</div>
+                <div className={clsx(styles.tableCell, 'tableCell')}>Type</div>
               </EqualHeightElement>
             )}
             {(!isOnlyDiff || !isIdentical.engineDisplacement) && (
               <EqualHeightElement name="motor">
-                <div className={styles.tableCell}>Motor</div>
+                <div className={clsx(styles.tableCell, 'tableCell')}>Motor</div>
               </EqualHeightElement>
             )}
             {(!isOnlyDiff || !isIdentical.enginePower) && (
               <EqualHeightElement name="enginepower">
-                <div className={styles.tableCell}>Engine Power</div>
+                <div className={clsx(styles.tableCell, 'tableCell')}>
+                  Engine Power
+                </div>
               </EqualHeightElement>
             )}
             {(!isOnlyDiff || !isIdentical.engine) && (
               <EqualHeightElement name="engine">
-                <div className={styles.tableCell}>Engine</div>
+                <div className={clsx(styles.tableCell, 'tableCell')}>
+                  Engine
+                </div>
               </EqualHeightElement>
             )}
             {(!isOnlyDiff || !isIdentical.drivetrainName) && (
               <EqualHeightElement name="wheeldrive">
-                <div className={styles.tableCell}>Wheel Drive</div>
+                <div className={clsx(styles.tableCell, 'tableCell')}>
+                  Wheel Drive
+                </div>
               </EqualHeightElement>
             )}
             {[...options].map((option) => {
               if (emptyOptions?.includes(option)) return;
               return (
                 <EqualHeightElement name={option} key={uuid4()}>
-                  <div className={styles.tableCell}>{option}</div>
+                  <div className={clsx(styles.tableCell, 'tableCell')}>
+                    {option}
+                  </div>
                 </EqualHeightElement>
               );
             })}
             {(!isOnlyDiff || !isIdentical.colorName) && (
-              <div className={styles.tableCell}>Color</div>
+              <div className={clsx(styles.tableCell, 'tableCell')}>Color</div>
             )}
           </div>
           <ScrollSyncPane>
@@ -134,31 +142,35 @@ const GeneralComparisonTable: React.FC<{ isOnlyDiff: boolean }> = ({
                   >
                     {(!isOnlyDiff || !isIdentical.bodyType) && (
                       <EqualHeightElement name="bodytype">
-                        <div className={styles.tableCell}>{info.bodyType}</div>
+                        <div className={clsx(styles.tableCell, 'tableCell')}>
+                          {info.bodyType}
+                        </div>
                       </EqualHeightElement>
                     )}
                     {(!isOnlyDiff || !isIdentical.engineDisplacement) && (
                       <EqualHeightElement name="motor">
-                        <div className={styles.tableCell}>
+                        <div className={clsx(styles.tableCell, 'tableCell')}>
                           {info.engineDisplacement} l.
                         </div>
                       </EqualHeightElement>
                     )}
                     {(!isOnlyDiff || !isIdentical.enginePower) && (
                       <EqualHeightElement name="enginepower">
-                        <div className={styles.tableCell}>
+                        <div className={clsx(styles.tableCell, 'tableCell')}>
                           {info.enginePower} h.p.
                         </div>
                       </EqualHeightElement>
                     )}
                     {(!isOnlyDiff || !isIdentical.engine) && (
                       <EqualHeightElement name="engine">
-                        <div className={styles.tableCell}>{info.engine}</div>
+                        <div className={clsx(styles.tableCell, 'tableCell')}>
+                          {info.engine}
+                        </div>
                       </EqualHeightElement>
                     )}
                     {(!isOnlyDiff || !isIdentical.drivetrainName) && (
                       <EqualHeightElement name="wheeldrive">
-                        <div className={styles.tableCell}>
+                        <div className={clsx(styles.tableCell, 'tableCell')}>
                           {info.drivetrainName}
                         </div>
                       </EqualHeightElement>
@@ -167,7 +179,9 @@ const GeneralComparisonTable: React.FC<{ isOnlyDiff: boolean }> = ({
                       (type: string) =>
                         !emptyOptions?.includes(type) && (
                           <EqualHeightElement name={type} key={uuid4()}>
-                            <div className={styles.tableCell}>
+                            <div
+                              className={clsx(styles.tableCell, 'tableCell')}
+                            >
                               {info.options[type]
                                 .filter(
                                   (option) =>
@@ -185,6 +199,7 @@ const GeneralComparisonTable: React.FC<{ isOnlyDiff: boolean }> = ({
                             styles.tableCell,
                             styles.colorCell,
                             styles.lastCell,
+                            'tableCell',
                           )}
                         >
                           <div

--- a/frontend/src/components/general-comparison-table/general-comparison-table.tsx
+++ b/frontend/src/components/general-comparison-table/general-comparison-table.tsx
@@ -129,7 +129,9 @@ const GeneralComparisonTable: React.FC<{ isOnlyDiff: boolean }> = ({
               );
             })}
             {(!isOnlyDiff || !isIdentical.colorName) && (
-              <div className={clsx(styles.tableCell, 'tableCell')}>Color</div>
+              <EqualHeightElement name="color">
+                <div className={clsx(styles.tableCell, 'tableCell')}>Color</div>
+              </EqualHeightElement>
             )}
           </div>
           <ScrollSyncPane>

--- a/frontend/src/components/general-comparison-table/styles.module.scss
+++ b/frontend/src/components/general-comparison-table/styles.module.scss
@@ -9,15 +9,13 @@
 }
 
 .tableCell {
+  height: 100%;
   min-height: 45px;
   margin: 0 1rem;
   padding: 1rem 0;
   line-height: 1.6;
   text-transform: capitalize;
-
-  &:not(:last-child) {
-    border-bottom: 1px solid var(--gray300);
-  }
+  border-bottom: 1px solid var(--gray300);
 }
 
 .tableTitles {
@@ -37,6 +35,10 @@
 .colorCell {
   display: flex;
   align-items: center;
+}
+
+.lastCell {
+  border-bottom: none;
 }
 
 .colorBox {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1919,6 +1919,11 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-equal-height@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-equal-height/-/react-equal-height-1.2.2.tgz#438b8170fa8b98f64f705f517e6c4d6889c9bd9b"
+  integrity sha512-iRL2Gcem5fwtsOzxMVwmCUiaaKyQ4Ba/jf4AIEGImIId8ub4Vop0kieg22yO0nt2HYW3+AfrJGIVid091lm2/A==
+
 react-hook-form@^7.34.2:
   version "7.34.2"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.34.2.tgz#9ac6d1a309a7c4aaa369d1269357a70e9e9bf4de"


### PR DESCRIPTION
`react-equal-height` was added to simplify adjusting table rows height.

This should fix bug https://app.asana.com/0/1202525679663009/1202961645454055 that appears from time to time on staging.

Bug: 
![image](https://user-images.githubusercontent.com/44324806/190171576-365a43bb-14a6-467b-978a-ead0fde35838.png)
