### PR TITLE
fix/Bug_105 Show cars brands not more, than max in slider

### DIFF
--- a/frontend/src/components/cars-categories/cars-categories.tsx
+++ b/frontend/src/components/cars-categories/cars-categories.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
 import { SliderNavButton } from '@components/cars-categories/slider-nav-button/slider-nav-button';
 import { swiperParams } from '@components/cars-categories/swiper-params';
+import { Spinner } from '@components/common/spinner/spinner';
 import { useGetBrandsQuery } from '@store/queries/cars';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
@@ -14,10 +15,46 @@ import styles from './styles.module.scss';
 const CarsCategories: FC = () => {
   const { data: brands } = useGetBrandsQuery();
 
+  const countOrAllExisted = useCallback(
+    (count: number): number => {
+      if (!brands) return count;
+      return brands?.length >= count ? count : brands?.length;
+    },
+    [brands],
+  );
+
+  const breakpoints = useMemo(
+    () =>
+      brands && {
+        320: {
+          slidesPerView: countOrAllExisted(3),
+        },
+        640: {
+          slidesPerView: countOrAllExisted(4),
+        },
+        820: {
+          slidesPerView: countOrAllExisted(5),
+        },
+        1080: {
+          slidesPerView: countOrAllExisted(6),
+        },
+        1300: {
+          slidesPerView: countOrAllExisted(8),
+        },
+      },
+    [brands],
+  );
+
+  if (!brands) return <Spinner />;
+
   return (
     <div className={styles.container}>
       <div className={styles.arrowWrapper}>
-        <Swiper className={styles.swiperWrapper} {...swiperParams}>
+        <Swiper
+          className={styles.swiperWrapper}
+          {...swiperParams}
+          breakpoints={breakpoints}
+        >
           <SliderNavButton direction="prev" />
           <SliderNavButton direction="next" />
 

--- a/frontend/src/components/cars-categories/swiper-params.ts
+++ b/frontend/src/components/cars-categories/swiper-params.ts
@@ -4,21 +4,4 @@ export const swiperParams: SwiperOptions = {
   loop: true,
   mousewheel: true,
   modules: [Navigation, Mousewheel],
-  breakpoints: {
-    320: {
-      slidesPerView: 3,
-    },
-    640: {
-      slidesPerView: 4,
-    },
-    820: {
-      slidesPerView: 5,
-    },
-    1080: {
-      slidesPerView: 6,
-    },
-    1300: {
-      slidesPerView: 8,
-    },
-  },
 };


### PR DESCRIPTION
See - https://app.asana.com/0/1202525679663009/1202979108662028/f

Also fixed issue when we couldn't scroll next.

### Max (6 brands):
![max-slides](https://user-images.githubusercontent.com/49813216/190154520-e136c816-53ff-441e-9727-0b5bd9b8f49a.gif)

### 4 brands
![4-slides](https://user-images.githubusercontent.com/49813216/190154838-f6664d5b-4e03-4fe0-aa4e-a3a76b693fc5.gif)