### PR TITLE
Added tables to prisma for autoria top cards

### DIFF
--- a/backend/prisma/migrations/20220916084403_add_users_autoria_viewed_cars/migration.sql
+++ b/backend/prisma/migrations/20220916084403_add_users_autoria_viewed_cars/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE `Users_Autoria_Viewed_Cars` (
+    `id` VARCHAR(191) NOT NULL,
+    `user_id` VARCHAR(191) NOT NULL,
+    `model_id` VARCHAR(300) NOT NULL,
+    `autoria_code` INTEGER NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Users_Autoria_Viewed_Cars` ADD CONSTRAINT `Users_Autoria_Viewed_Cars_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Users_Autoria_Viewed_Cars` ADD CONSTRAINT `Users_Autoria_Viewed_Cars_model_id_fkey` FOREIGN KEY (`model_id`) REFERENCES `Model`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20220916090124_add_autoria_cars_details/migration.sql
+++ b/backend/prisma/migrations/20220916090124_add_autoria_cars_details/migration.sql
@@ -1,0 +1,46 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[autoria_code]` on the table `City` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[autoria_code]` on the table `Fuel_Type` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[autoria_code]` on the table `Transmission_Type` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateTable
+CREATE TABLE `Autoria_Cars_Details` (
+    `id` VARCHAR(191) NOT NULL,
+    `model_id` VARCHAR(300) NOT NULL,
+    `autoria_code` INTEGER NOT NULL,
+    `race` INTEGER NOT NULL,
+    `city_id` VARCHAR(300) NULL,
+    `transmission_type_id` VARCHAR(300) NULL,
+    `fuel_type_id` VARCHAR(300) NULL,
+    `price` INTEGER NOT NULL,
+    `autoria_url` VARCHAR(300) NULL,
+    `photo_url` VARCHAR(300) NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `Autoria_Cars_Details_autoria_code_key`(`autoria_code`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `City_autoria_code_key` ON `City`(`autoria_code`);
+
+-- CreateIndex
+CREATE UNIQUE INDEX `Fuel_Type_autoria_code_key` ON `Fuel_Type`(`autoria_code`);
+
+-- CreateIndex
+CREATE UNIQUE INDEX `Transmission_Type_autoria_code_key` ON `Transmission_Type`(`autoria_code`);
+
+-- AddForeignKey
+ALTER TABLE `Autoria_Cars_Details` ADD CONSTRAINT `Autoria_Cars_Details_model_id_fkey` FOREIGN KEY (`model_id`) REFERENCES `Model`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Autoria_Cars_Details` ADD CONSTRAINT `Autoria_Cars_Details_city_id_fkey` FOREIGN KEY (`city_id`) REFERENCES `City`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Autoria_Cars_Details` ADD CONSTRAINT `Autoria_Cars_Details_transmission_type_id_fkey` FOREIGN KEY (`transmission_type_id`) REFERENCES `Transmission_Type`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Autoria_Cars_Details` ADD CONSTRAINT `Autoria_Cars_Details_fuel_type_id_fkey` FOREIGN KEY (`fuel_type_id`) REFERENCES `Fuel_Type`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   viewed_cars         Users_Viewed_Cars[]
   user_comparisons    Comparison[]
   users_searches_cars Users_Searches_Cars[]
+  autoria_viewed_cars Users_Autoria_Viewed_Cars[]
 }
 
 model User_Security {
@@ -68,6 +69,16 @@ model Users_Searches_Cars {
   created_at          DateTime            @default(now())
 }
 
+model Users_Autoria_Viewed_Cars {
+  id              String   @id @default(uuid())
+  user            User     @relation(fields: [user_id], references: [id])
+  user_id         String
+  model           Model    @relation(fields: [model_id], references: [id])
+  model_id        String   @db.VarChar(300)
+  autoria_code    Int
+  created_at      DateTime @default(now())
+}
+
 model Body_Type {
   id           String @id @default(uuid())
   name         String @db.VarChar(300)
@@ -109,6 +120,7 @@ model Model {
   prices_ranges          Prices_Range[]
   users_wishlists        User_Wishlist[]
   users_searches_cars    Users_Searches_Cars[]
+  autoria_viewed_cars    Users_Autoria_Viewed_Cars[]
   created_at          DateTime            @default(now())
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -79,6 +79,24 @@ model Users_Autoria_Viewed_Cars {
   created_at      DateTime @default(now())
 }
 
+model Autoria_Cars_Details {
+  id                   String             @id @default(uuid())
+  model                Model              @relation(fields: [model_id], references: [id])
+  model_id             String             @db.VarChar(300)
+  autoria_code         Int                @unique @db.Int
+  race                 Int
+  city                 City?              @relation(fields: [city_id], references: [id])
+  city_id              String?            @db.VarChar(300)
+  transmission_type    Transmission_Type? @relation(fields: [transmission_type_id], references: [id])
+  transmission_type_id String?            @db.VarChar(300)
+  fuel_type            Fuel_Type?         @relation(fields: [fuel_type_id], references: [id])
+  fuel_type_id         String?            @db.VarChar(300)
+  price                Int
+  autoria_url          String?            @db.VarChar(300)
+  photo_url            String?            @db.VarChar(300)
+  created_at           DateTime           @default(now())
+}
+
 model Body_Type {
   id           String @id @default(uuid())
   name         String @db.VarChar(300)
@@ -121,6 +139,7 @@ model Model {
   users_wishlists        User_Wishlist[]
   users_searches_cars    Users_Searches_Cars[]
   autoria_viewed_cars    Users_Autoria_Viewed_Cars[]
+  autoria_cars_details   Autoria_Cars_Details[]
   created_at          DateTime            @default(now())
 }
 
@@ -134,8 +153,9 @@ model Drivetrain {
 model Fuel_Type {
   id             String @id @default(uuid())
   name           String @db.VarChar(300)
-  autoria_code   Int
+  autoria_code   Int @unique @db.Int
   complectations Complectation[]
+  autoria_cars_details Autoria_Cars_Details[]
 }
 
 model Color {
@@ -148,8 +168,9 @@ model Color {
 model Transmission_Type {
   id             String @id @default(uuid())
   name           String @db.VarChar(300)
-  autoria_code   Int
+  autoria_code   Int @unique @db.Int
   complectations Complectation[]
+  autoria_cars_details Autoria_Cars_Details[]
 }
 
 model Option {
@@ -205,11 +226,12 @@ model Prices_Range {
 }
 
 model City {
-  id           String @id @default(uuid())
-  name         String @db.VarChar(300)
-  autoria_code Int
-  region_id    String
-  region       Region @relation(fields: [region_id], references: [id])
+  id                   String @id @default(uuid())
+  name                 String @db.VarChar(300)
+  autoria_code         Int @unique @db.Int
+  region_id            String
+  region               Region @relation(fields: [region_id], references: [id])
+  autoria_cars_details Autoria_Cars_Details[]
 }
 
 model Region {


### PR DESCRIPTION
A unique constraint covering the columns `[autoria_code]` on the tables `City`, `Fuel_Type`, `Transmission_Type` will be added. If there are existing duplicate values, this will fail.
I guess we don't have duplicates in these tables and we don't need to.