### PR TITLE
Modified title of the comparison table

### DIFF
--- a/frontend/src/common/types/title/title.ts
+++ b/frontend/src/common/types/title/title.ts
@@ -1,6 +1,8 @@
+import { ReactNode } from 'react';
+
 export type TitlePropsType = {
   className?: string;
   element: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-  children: string;
+  children: string | ReactNode;
   id?: string;
 };

--- a/frontend/src/components/comp-top-table-bar/comp-top-table-bar.tsx
+++ b/frontend/src/components/comp-top-table-bar/comp-top-table-bar.tsx
@@ -55,12 +55,14 @@ export const CompTopTableBar = ({
           text="+Add to Comparison"
           className={styles.btnOutline}
         />
-        <div className={styles.clearBtn} onClick={handleClearBtnClick}>
-          <button className={clsx(styles.button, styles.iconButton)}>
-            <TrashCanIcon />
-          </button>
-          <div className={styles.clearBtnText}>Clear the Table</div>
-        </div>
+        {!initialData?.length || (
+          <div className={styles.clearBtn} onClick={handleClearBtnClick}>
+            <button className={clsx(styles.button, styles.iconButton)}>
+              <TrashCanIcon />
+            </button>
+            <div className={styles.clearBtnText}>Clear the Table</div>
+          </div>
+        )}
       </div>
       <ScrollSyncPane>
         <div className={clsx('styledScrollbar', styles.slider)}>

--- a/frontend/src/components/comparison-page/comparison-page.tsx
+++ b/frontend/src/components/comparison-page/comparison-page.tsx
@@ -33,7 +33,8 @@ const ComparisonPage: React.FC = () => {
       <Header />
       <PageContainer>
         <Title id="comparisonTitle" element="h3">
-          Comparison
+          Comparing by <span className={styles.count}>{data?.length}</span>{' '}
+          complectations
         </Title>
         <ScrollSync>
           <div className={styles.tablesWrapper}>

--- a/frontend/src/components/comparison-page/styles.module.scss
+++ b/frontend/src/components/comparison-page/styles.module.scss
@@ -26,3 +26,7 @@
   color: var(--white);
   background-color: var(--blue100);
 }
+
+.count {
+  color: var(--blue100);
+}


### PR DESCRIPTION
See - https://app.asana.com/0/1202525679663009/1203004017195888/f

![image](https://user-images.githubusercontent.com/49813216/191124876-0454d3f7-20ee-4b37-9e5d-ab950ea47442.png)
![image](https://user-images.githubusercontent.com/49813216/191125030-cf072d8d-e9da-4b8f-a99c-cdc1dd4e3c32.png)
![comparison-title](https://user-images.githubusercontent.com/49813216/191124902-17e15355-a651-4209-95df-ac02390bfe64.gif)

### Additional fix: 
Hiding "Clear the Table" when table is empty.
![button-hiding](https://user-images.githubusercontent.com/49813216/191126353-83655a7e-aecf-4104-ac19-a25c58f2e6e7.gif)
