### PR TITLE
fix/Bug_132 Random order in popup

### DIFF
--- a/backend/src/controllers/comparisons/comparisons.controller.ts
+++ b/backend/src/controllers/comparisons/comparisons.controller.ts
@@ -12,16 +12,21 @@ import httpStatus from 'http-status-codes';
 
 const addCarToComparison = async (
   req: TypedRequestBody<{
-    complectationId: string;
+    complectationId: string | string[];
     lastPosition?: number;
   }>,
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const comparison = await comparisonsService.addCarToComparison({
-      complectationId: req.body.complectationId,
-      lastPosition: req.body.lastPosition,
+    const { complectationId, lastPosition } = req.body;
+
+    const complectationIds =
+      typeof complectationId === 'string' ? [complectationId] : complectationId;
+
+    const comparison = await comparisonsService.addCarsToComparison({
+      complectationIds,
+      lastPosition,
       userId: req.tokenPayload.sub,
     });
     res.status(httpStatus.CREATED).json(comparison);

--- a/frontend/src/components/comparison-popup/comparison-popup.tsx
+++ b/frontend/src/components/comparison-popup/comparison-popup.tsx
@@ -135,9 +135,7 @@ const ComparisonPopup: FC<ComparisonPopupProps> = ({
     carsToRemove?.forEach(({ id }) => {
       deleteCarFromComparison({ complectationId: id });
     });
-    carsToAdd?.forEach(({ id }) => {
-      addCarToComparison({ complectationId: id });
-    });
+    addCarToComparison({ complectationId: carsToAdd.map((i) => i.id) });
 
     handleClose();
   };

--- a/frontend/src/store/queries/comparisons/index.ts
+++ b/frontend/src/store/queries/comparisons/index.ts
@@ -6,7 +6,7 @@ import { API } from '@store/queries/api-routes';
 import { api } from '..';
 
 interface ComparisonsRequest {
-  complectationId: string;
+  complectationId: string | string[];
   lastPosition?: number;
 }
 


### PR DESCRIPTION
See - https://app.asana.com/0/1202525679663009/1203025912822604/f

The issue was in sequentional mutation queries in forEach cycle. Therefore server handled requests in unexpected order. 
Instead of iterating on every Id in forEach and creating separate mutations, I made the ability to pass an array of Ids in a single mutation.

### Result:
![result](https://user-images.githubusercontent.com/49813216/191618440-f30254d3-5e1e-4507-a83d-0e30d285f463.gif)
